### PR TITLE
Fix deploy.sh profile authentication failure

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -38,9 +38,7 @@ print_timing() {
 print_timing "Loading environment variables"
 if [ -f .env.local ]
 then
-  set -a
   source .env.local
-  set +a
 fi
 
 # Validate required configuration


### PR DESCRIPTION
Fixes issue #1 (deploy.sh authentication failure with profile-based auth)

 This PR resolves an authentication bug where `deploy.sh` fails when using profile-based authentication.
  
Changes:
  - Remove set -a and set +a from environment loading in deploy.sh
  - Variables are now loaded but not automatically exported, preventing empty DATABRICKS_HOST/DATABRICKS_TOKEN from interfering with profile auth